### PR TITLE
trigger

### DIFF
--- a/.github/labeler.yml
+++ b/.github/labeler.yml
@@ -20,6 +20,14 @@
         - scripts/**/*
         - win32/build/**/*
 
+"Category: CI":
+  - changed-files:
+      - any-glob-to-any-file:
+          - .circleci/**
+          - .github/**
+          - !.github/lsan-suppressions.txt
+          - !.github/ISSUE_TEMPLATE/**
+
 "Extension: bcmath":
   - changed-files:
       - any-glob-to-any-file:

--- a/.github/labeler.yml
+++ b/.github/labeler.yml
@@ -25,8 +25,8 @@
       - any-glob-to-any-file:
           - .circleci/**
           - .github/**
-          - !.github/lsan-suppressions.txt
-          - !.github/ISSUE_TEMPLATE/**
+          - '!.github/lsan-suppressions.txt'
+          - '!.github/ISSUE_TEMPLATE/**'
 
 "Extension: bcmath":
   - changed-files:

--- a/.github/setup_hmailserver.php
+++ b/.github/setup_hmailserver.php
@@ -16,6 +16,7 @@ $domain->Save();
 
 $accounts = $domain->accounts();
 
+
 foreach (IMAP_USERS as $user) {
     $account = $accounts->Add();
     $account->Address = "$user@" . IMAP_MAIL_DOMAIN;


### PR DESCRIPTION
We have a "Category: CI" label in GH issues and PRs, but there is no
labeler rule to automatically mark PRs as such.

This adds a labeler rule to automatically add the "Category: CI" label
if the PR changes _any_ file in:

  - .circleci/*
  - .github/actions/**/*
  - .github/CODEOWNERS
  - .github/setup_hmailserver.php
  - .github/nightly_matrix.php
  - .github/scripts/*
  - .github/scripts/**/*
  - .github/labeler.yml
  - .github/workflows/*