### PR TITLE
t1

### DIFF
--- a/.github/labeler.yml
+++ b/.github/labeler.yml
@@ -25,6 +25,7 @@
       - any-glob-to-any-file:
         - .circleci/**
         - .github/**
+      - all-globs-to-all-files:
         - '!.github/lsan-suppressions.txt'
         - '!.github/ISSUE_TEMPLATE/**'
 

--- a/.github/workflows/close-needs-feedback.yml
+++ b/.github/workflows/close-needs-feedback.yml
@@ -4,6 +4,7 @@ on:
   schedule:
     - cron: "0 0 * * *"
 
+
 permissions:
   contents: read
 


### PR DESCRIPTION
We have a "Category: CI" label in GH issues and PRs, but there is no
labeler rule to automatically mark PRs as such.

This adds a labeler rule to automatically add the "Category: CI" label
if the PR changes _any_ file in:

  - .circleci/*
  - .github/actions/**/*
  - .github/CODEOWNERS
  - .github/setup_hmailserver.php
  - .github/nightly_matrix.php
  - .github/scripts/*
  - .github/scripts/**/*
  - .github/labeler.yml
  - .github/workflows/*