### PR TITLE
t2

### DIFF
--- a/.github/labeler.yml
+++ b/.github/labeler.yml
@@ -25,6 +25,7 @@
       - any-glob-to-any-file:
         - .circleci/**
         - .github/**
+      - all-globs-to-all-files:
         - '!.github/lsan-suppressions.txt'
         - '!.github/ISSUE_TEMPLATE/**'
 

--- a/ext/bcmath/bcmath.stub.php
+++ b/ext/bcmath/bcmath.stub.php
@@ -2,6 +2,7 @@
 
 /** @generate-class-entries */
 
+
 namespace
 {
     /** @refcount 1 */


### PR DESCRIPTION
We have a "Category: CI" label in GH issues and PRs, but there is no
labeler rule to automatically mark PRs as such.

This adds a labeler rule to automatically add the "Category: CI" label
if the PR changes _any_ file in:

  - .circleci/*
  - .github/actions/**/*
  - .github/CODEOWNERS
  - .github/setup_hmailserver.php
  - .github/nightly_matrix.php
  - .github/scripts/*
  - .github/scripts/**/*
  - .github/labeler.yml
  - .github/workflows/*