### PR TITLE
t4

### DIFF
--- a/.github/workflows/close-needs-feedback.yml
+++ b/.github/workflows/close-needs-feedback.yml
@@ -4,6 +4,7 @@ on:
   schedule:
     - cron: "0 0 * * *"
 
+
 permissions:
   contents: read
 


### PR DESCRIPTION
We have a "Category: CI" label in GH issues and PRs, but there is no
labeler rule to automatically mark PRs as such.

This adds a labeler rule to automatically add the "Category: CI" label
if the PR changes _any_ file in:

  - .circleci/*
  - .github/actions/**/*
  - .github/CODEOWNERS
  - .github/setup_hmailserver.php
  - .github/nightly_matrix.php
  - .github/scripts/*
  - .github/scripts/**/*
  - .github/labeler.yml
  - .github/workflows/*